### PR TITLE
Enable coverage from Spring driven tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ public static ProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.crea
 
 Running your JUnit tests now leaves **html** files for inidividual test methods as well as whole test classes in your project's `target/process-test-coverage` folder. Just open one, check yourself - and have fun with your process tests! :smile:
 
+## New! Get Started with Spring Testing (version 0.2.9 upwards)
+
+See a unit test example wired for Spring Testing here: https://github.com/camunda/camunda-bpm-process-test-coverage/blob/master/test/src/test/java/process_test_coverage/spring/SpringProcessWithCoverageTest.java
+
 ## Further resources
 * [JavaDoc](https://camunda.github.io/camunda-process-test-coverage/javadoc)
 * [Issues](https://github.com/camunda/camunda-process-test-coverage/issues)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,17 @@
         <dependency>
             <groupId>org.camunda.bpm</groupId>
             <artifactId>camunda-engine</artifactId>
-            <version>RELEASE</version>
+            <version>RELEASE</version> <!-- We intentionally always compile against RELEASE, but
+                                            test against many versions *provided* by user projects.
+                                            Therefore the tests are in a separate module. -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.camunda.bpm</groupId>
+            <artifactId>camunda-engine-spring</artifactId>
+            <version>RELEASE</version> <!-- We intentionally always compile against RELEASE, but
+                                            test against many versions *provided* by user projects.
+                                            Therefore the tests are in a separate module. -->
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/ProcessCoverageConfigurator.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/ProcessCoverageConfigurator.java
@@ -1,0 +1,51 @@
+package org.camunda.bpm.extension.process_test_coverage.junit.rules;
+
+import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseListener;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.event.EventHandler;
+import org.camunda.bpm.extension.process_test_coverage.listeners.CompensationEventCoverageHandler;
+import org.camunda.bpm.extension.process_test_coverage.listeners.FlowNodeHistoryEventHandler;
+import org.camunda.bpm.extension.process_test_coverage.listeners.PathCoverageParseListener;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Helper methods to configure the process coverage extensions on a given ProcessEngineConfigurationImpl
+ *
+ * @author z0rbas / lldata
+ *
+ */
+public class ProcessCoverageConfigurator {
+
+    public static void initializeProcessCoverageExtensions(ProcessEngineConfigurationImpl configuration) {
+        initializeFlowNodeHandler(configuration);
+        initializePathCoverageParseListener(configuration);
+        initializeCompensationEventHandler(configuration);
+    }
+
+    private static void initializePathCoverageParseListener(ProcessEngineConfigurationImpl configuration) {
+        List<BpmnParseListener> bpmnParseListeners = configuration.getCustomPostBPMNParseListeners();
+        if (bpmnParseListeners == null) {
+            bpmnParseListeners = new LinkedList<BpmnParseListener>();
+            configuration.setCustomPostBPMNParseListeners(bpmnParseListeners);
+        }
+
+        bpmnParseListeners.add(new PathCoverageParseListener());
+    }
+
+    private static void initializeFlowNodeHandler(ProcessEngineConfigurationImpl configuration) {
+        final FlowNodeHistoryEventHandler historyEventHandler = new FlowNodeHistoryEventHandler();
+        configuration.setHistoryEventHandler(historyEventHandler);
+
+    }
+
+    private static void initializeCompensationEventHandler(ProcessEngineConfigurationImpl configuration) {
+        if (configuration.getCustomEventHandlers() == null) {
+            configuration.setCustomEventHandlers(new LinkedList<EventHandler>());
+        }
+
+        configuration.getCustomEventHandlers().add(new CompensationEventCoverageHandler());
+    }
+
+}

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/ProcessCoverageInMemProcessEngineConfiguration.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/ProcessCoverageInMemProcessEngineConfiguration.java
@@ -1,14 +1,6 @@
 package org.camunda.bpm.extension.process_test_coverage.junit.rules;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseListener;
 import org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
-import org.camunda.bpm.engine.impl.event.EventHandler;
-import org.camunda.bpm.extension.process_test_coverage.listeners.CompensationEventCoverageHandler;
-import org.camunda.bpm.extension.process_test_coverage.listeners.FlowNodeHistoryEventHandler;
-import org.camunda.bpm.extension.process_test_coverage.listeners.PathCoverageParseListener;
 
 /**
  * Standalone in memory process engine configuration additionally configuring
@@ -22,42 +14,8 @@ public class ProcessCoverageInMemProcessEngineConfiguration extends StandaloneIn
 
     @Override
     protected void init() {
-
-        initializeFlowNodeHandler();
-
-        initializePathCoverageParseListener();
-
-        initializeCompensationEventHandler();
-        
+        ProcessCoverageConfigurator.initializeProcessCoverageExtensions(this);
         super.init();
-    }
-
-    private void initializePathCoverageParseListener() {
-
-        List<BpmnParseListener> bpmnParseListeners = getCustomPostBPMNParseListeners();
-        if (bpmnParseListeners == null) {
-            bpmnParseListeners = new LinkedList<BpmnParseListener>();
-            setCustomPostBPMNParseListeners(bpmnParseListeners);
-        }
-
-        bpmnParseListeners.add(new PathCoverageParseListener());
-    }
-
-    private void initializeFlowNodeHandler() {
-
-        final FlowNodeHistoryEventHandler historyEventHandler = new FlowNodeHistoryEventHandler();
-        setHistoryEventHandler(historyEventHandler);
-
-    }
-
-    private void initializeCompensationEventHandler() {
-
-        if (getCustomEventHandlers() == null) {
-            setCustomEventHandlers(new LinkedList<EventHandler>());
-        }
-
-        customEventHandlers.add(new CompensationEventCoverageHandler());
-
     }
 
 }

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/TestCoverageProcessEngineRule.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/TestCoverageProcessEngineRule.java
@@ -1,5 +1,15 @@
 package org.camunda.bpm.extension.process_test_coverage.junit.rules;
 
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseListener;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.event.EventHandler;
@@ -18,15 +28,6 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.Description;
-
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Rule handling the process test coverage for individual test methods and the
@@ -73,6 +74,14 @@ public class TestCoverageProcessEngineRule extends ProcessEngineRule {
      */
     private Map<String, Collection<Matcher<Double>>> testMethodNameToCoverageMatchers = new HashMap<String, Collection<Matcher<Double>>>();
 
+    TestCoverageProcessEngineRule() {
+        super();
+    }
+
+    TestCoverageProcessEngineRule(ProcessEngine processEngine) {
+        super(processEngine);
+    }
+
     /**
      * Adds an assertion for a test method's coverage percentage.
      * 
@@ -106,7 +115,9 @@ public class TestCoverageProcessEngineRule extends ProcessEngineRule {
 
         validateRuleAnnotations(description);
 
-        super.initializeProcessEngine();
+        if (processEngine == null) {
+            super.initializeProcessEngine();
+        }
 
         initializeRunState(description);
 

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/TestCoverageProcessEngineRuleBuilder.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/TestCoverageProcessEngineRuleBuilder.java
@@ -1,5 +1,7 @@
 package org.camunda.bpm.extension.process_test_coverage.junit.rules;
 
+import org.camunda.bpm.engine.ProcessEngine;
+
 /**
  * Fluent Builder for TestCoverageProcessEngineRule.
  *
@@ -14,16 +16,34 @@ public class TestCoverageProcessEngineRuleBuilder {
      */
     public static final String DEFAULT_ASSERT_AT_LEAST_PROPERTY = "org.camunda.bpm.extension.process_test_coverage.ASSERT_AT_LEAST";
 
-    private TestCoverageProcessEngineRule rule = new TestCoverageProcessEngineRule();
+    private final TestCoverageProcessEngineRule rule;
+
+    private TestCoverageProcessEngineRuleBuilder() {
+        this.rule = new TestCoverageProcessEngineRule();
+    }
+
+    private TestCoverageProcessEngineRuleBuilder(ProcessEngine processEngine) {
+        this.rule = new TestCoverageProcessEngineRule(processEngine);
+    }
 
     /**
      * Creates a TestCoverageProcessEngineRuleBuilder with the default class
      * coverage assertion property activated.
-     * 
+     *
      * @return
      */
     public static TestCoverageProcessEngineRuleBuilder create() {
         return createBase().optionalAssertCoverageAtLeastProperty(DEFAULT_ASSERT_AT_LEAST_PROPERTY);
+    }
+
+    /**
+     * Creates a TestCoverageProcessEngineRuleBuilder with the default class
+     * coverage assertion property activated.
+     *
+     * @return
+     */
+    public static TestCoverageProcessEngineRuleBuilder create(ProcessEngine processEngine) {
+        return createBase(processEngine).optionalAssertCoverageAtLeastProperty(DEFAULT_ASSERT_AT_LEAST_PROPERTY);
     }
 
     /**
@@ -54,6 +74,11 @@ public class TestCoverageProcessEngineRuleBuilder {
     /** @return a basic builder with nothing preconfigured */
     public static TestCoverageProcessEngineRuleBuilder createBase() {
         return new TestCoverageProcessEngineRuleBuilder();
+    }
+
+    /** @return a basic builder with nothing preconfigured */
+    public static TestCoverageProcessEngineRuleBuilder createBase(ProcessEngine processEngine) {
+        return new TestCoverageProcessEngineRuleBuilder(processEngine);
     }
 
     /**

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/spring/SpringProcessWithCoverageEngineConfiguration.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/spring/SpringProcessWithCoverageEngineConfiguration.java
@@ -1,0 +1,19 @@
+package org.camunda.bpm.extension.process_test_coverage.spring;
+
+import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.ProcessCoverageConfigurator;
+
+/**
+ * Spring process engine configuration additionally configuring
+ * flow node, sequence flow and compensation listeners for process coverage
+ * testing.
+ *
+ * Created by lldata on 20-10-2016.
+ */
+public class SpringProcessWithCoverageEngineConfiguration extends SpringProcessEngineConfiguration {
+
+	public void init() {
+		ProcessCoverageConfigurator.initializeProcessCoverageExtensions(this);
+		super.init();
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,23 @@
 			<version>1.3.168</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<!-- Needed to test SpringProcessWithCoverageTest -->
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<version>3.1.2.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<!-- Needed to test SpringProcessWithCoverageTest -->
+			<groupId>cglib</groupId>
+			<artifactId>cglib</artifactId>
+			<version>2.2.2</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -32,6 +32,12 @@
             <version>${camunda.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.camunda.bpm</groupId>
+            <artifactId>camunda-engine-spring</artifactId>
+            <version>${camunda.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test/src/test/java/process_test_coverage/spring/InMemProcessEngineConfiguration.java
+++ b/test/src/test/java/process_test_coverage/spring/InMemProcessEngineConfiguration.java
@@ -1,0 +1,83 @@
+package process_test_coverage.spring;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.el.ExpressionManager;
+import org.camunda.bpm.engine.spring.ProcessEngineFactoryBean;
+import org.camunda.bpm.engine.spring.SpringExpressionManager;
+import org.camunda.bpm.extension.process_test_coverage.spring.SpringProcessWithCoverageEngineConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+
+/**
+ * Adapted from: https://github.com/camunda/camunda-bpm-platform/blob/master/engine-spring/src/test/java/org/camunda/bpm/engine/spring/test/configuration/InMemProcessEngineConfiguration.java
+ */
+@Configuration
+public class InMemProcessEngineConfiguration {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Bean
+  public DataSource dataSource() {
+
+    SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
+
+    dataSource.setDriverClass(org.h2.Driver.class);
+    dataSource.setUrl("jdbc:h2:mem:camunda-test;DB_CLOSE_DELAY=-1");
+    dataSource.setUsername("sa");
+    dataSource.setPassword("");
+
+    return dataSource;
+
+  }
+
+  @Bean
+  public PlatformTransactionManager transactionManager() {
+
+    return new DataSourceTransactionManager(dataSource());
+
+  }
+
+  @Bean
+  public ProcessEngineConfigurationImpl processEngineConfiguration() throws IOException {
+
+    SpringProcessWithCoverageEngineConfiguration config = new SpringProcessWithCoverageEngineConfiguration();
+
+    config.setExpressionManager(expressionManager());
+    config.setTransactionManager(transactionManager());
+    config.setDataSource(dataSource());
+    config.setDatabaseSchemaUpdate("true");
+    config.setHistory(ProcessEngineConfiguration.HISTORY_FULL);
+    config.setJobExecutorActivate(false);
+
+    config.init();
+    return config;
+
+  }
+
+  @Bean
+  ExpressionManager expressionManager() {
+
+    return new SpringExpressionManager(applicationContext, null);
+
+  }
+
+  @Bean
+  public ProcessEngineFactoryBean processEngine() throws IOException {
+
+    ProcessEngineFactoryBean factoryBean = new ProcessEngineFactoryBean();
+    factoryBean.setProcessEngineConfiguration(processEngineConfiguration());
+    return factoryBean;
+
+  }
+
+}

--- a/test/src/test/java/process_test_coverage/spring/SpringProcessWithCoverageTest.java
+++ b/test/src/test/java/process_test_coverage/spring/SpringProcessWithCoverageTest.java
@@ -1,0 +1,50 @@
+package process_test_coverage.spring;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.annotation.PostConstruct;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { InMemProcessEngineConfiguration.class })
+public class SpringProcessWithCoverageTest {
+
+  @Autowired
+  ProcessEngine processEngine;
+
+  @Rule @ClassRule
+  public static ProcessEngineRule rule;
+
+  @PostConstruct
+  void initRule() {
+    rule = TestCoverageProcessEngineRuleBuilder.create(processEngine).build();
+  }
+
+  @Test
+  @Deployment(resources="process.bpmn")
+  public void start_and_finish_process() {
+
+    Map<String, Object> variables = new HashMap<String, Object>();
+    variables.put("path", "A");
+    final ProcessInstance processInstance = processEngine.getRuntimeService().startProcessInstanceByKey("process-test-coverage", variables);
+
+    Assert.assertNotNull(processInstance);
+    Assert.assertTrue(processInstance.isEnded());
+
+  }
+
+}


### PR DESCRIPTION
Extend constructors and builders of Junit rules. And provide a coverage
configuration that extends SpringProcessEngineConfiguration

Seems to be just enough for now to enable:
https://github.com/camunda/camunda-bpm-process-test-coverage/issues/9 
