### PR TITLE
Typos, Add Open JDK8 to Travis, Remove 6 and 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jdk:
   - openjdk6
 env:
   - CAMUNDA=LATEST
+  - CAMUNDA=7.9.0
+  - CAMUNDA=7.8.0
   - CAMUNDA=7.7.0
   - CAMUNDA=7.6.0
   - CAMUNDA=7.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: trusty
 sudo: false
 language: java
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
+  - openjdk8
 env:
   - CAMUNDA=LATEST
   - CAMUNDA=7.9.0

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Camunda BPM community extension **visualises** test process **paths** and *
 
 * Integrates with all versions of Camunda BPM starting with 7.3.0 and upwards 
 * Works with all relevant Java versions: 1.6, 1.7 and 1.8 - using **JUnit 4.12** (4.11 does not work)
-* Is continuously checked against latest Camunda BPM releases - see the full [**travis-ci**](https://travis-ci.org/camunda/camunda-bpm-process-test-coverage) matrix for details
+* Is continuously checked against latest Camunda BPM releases - see the full [**travis-ci**](https://travis-ci.org/AntoCuc/camunda-bpm-process-test-coverage) matrix for details
 
 ## Get started with *3 simple steps*
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # <img src="/doc/img/camunda.png" width="23" height="23" />&nbsp;Camunda&nbsp;BPM&nbsp;Process&nbsp;Test&nbsp;Coverage&nbsp;<a href="https://maven-badges.herokuapp.com/maven-central/org.camunda.bpm.extension/camunda-bpm-process-test-coverage"><img src="https://maven-badges.herokuapp.com/maven-central/org.camunda.bpm.extension/camunda-bpm-process-test-coverage/badge.svg" /></a> 
 
-This Camunda BPM community extension **visualises** test process **pathes** and **checks** your process model **coverage** ratio. Running  typical JUnit tests now leaves **html** files in your build output. Just open one and check yourself what your test did:
+This Camunda BPM community extension **visualises** test process **paths** and **checks** your process model **coverage** ratio. Running  typical JUnit tests now leaves **html** files in your build output. Just open one and check yourself what your test did:
 
 ![Insurance Application](/doc/img/insurance-application.png)
 
 ## Highlights
 
-* **Visually verify** the pathes covered by individual tests **methods** and whole test **classes**
+* **Visually verify** the paths covered by individual tests **methods** and whole test **classes**
 * Visually check gateway **expressions** and transaction borders (**savepoints**) used by your process
 * Calculate and **verify** the nodes (_and_ sequence flow) **coverage** ratio reached by tests methods and classes
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Camunda BPM community extension **visualises** test process **paths** and *
 
 * Integrates with all versions of Camunda BPM starting with 7.3.0 and upwards 
 * Works with all relevant Java versions: 1.6, 1.7 and 1.8 - using **JUnit 4.12** (4.11 does not work)
-* Is continuously checked against latest Camunda BPM releases - see the full [**travis-ci**](https://travis-ci.org/AntoCuc/camunda-bpm-process-test-coverage) matrix for details
+* Is continuously checked against latest Camunda BPM releases - see the full [**travis-ci**](https://travis-ci.org/camunda/camunda-bpm-process-test-coverage) matrix for details
 
 ## Get started with *3 simple steps*
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@
                 <version>3.5.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
-                    <source>${maven.compiler.target}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Re: Removal of JDK 6 and 7 it is due to
TLDR; builds have no chance of passing on these JDKs due to lack of support for TLS 1.2

https://blog.github.com/2018-02-02-weak-cryptographic-standards-removal-notice/
https://blog.github.com/2018-02-23-weak-cryptographic-standards-removed/

Also being adopted by Travis, etc.