### PR TITLE
Feature/not cover runtime mocked processes

### DIFF
--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
@@ -1,6 +1,7 @@
 package org.camunda.bpm.extension.process_test_coverage.model;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
@@ -59,8 +59,10 @@ public class MethodCoverage implements AggregatedCoverage {
 
         final String processDefinitionKey = element.getProcessDefinitionKey();
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+        if (processCoverage != null) {
+            processCoverage.addCoveredElement(element);
+        }
 
-        processCoverage.addCoveredElement(element);
     }
 
     /**
@@ -72,8 +74,9 @@ public class MethodCoverage implements AggregatedCoverage {
 
         final String processDefinitionKey = element.getProcessDefinitionKey();
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
-
-        processCoverage.endCoveredElement(element);
+        if (processCoverage != null) {
+            processCoverage.endCoveredElement(element);
+        }
     }
 
     /**
@@ -214,14 +217,22 @@ public class MethodCoverage implements AggregatedCoverage {
     public Set<String> getCoveredFlowNodeIds(String processDefinitionKey) {
 
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
-        return processCoverage.getCoveredFlowNodeIds();
+        if (processCoverage != null) {
+            return processCoverage.getCoveredFlowNodeIds();
+        } else {
+            return Collections.emptySet();
+        }
     }
 
     @Override
     public Set<CoveredFlowNode> getCoveredFlowNodes(String processDefinitionKey) {
 
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
-        return processCoverage.getCoveredFlowNodes();
+        if (processCoverage != null) {
+            return processCoverage.getCoveredFlowNodes();
+        } else {
+            return Collections.emptySet();
+        }
     }
 
     /**
@@ -231,7 +242,11 @@ public class MethodCoverage implements AggregatedCoverage {
     public Set<String> getCoveredSequenceFlowIds(String processDefinitionKey) {
 
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
-        return processCoverage.getCoveredSequenceFlowIds();
+        if (processCoverage != null) {
+            return processCoverage.getCoveredSequenceFlowIds();
+        } else {
+            return Collections.emptySet();
+        }
     }
 
     /**


### PR DESCRIPTION
Added the check on null processCoverage - in a case, when process was deployed in runtime (without @Deployment annotation), e.g. for Call Activity mocking (as described here at par.2: https://github.com/camunda/camunda-bpm-assert-scenario/issues/14#issuecomment-261700225). In this situation we dont need calculate coverage for this mocking process