### PR TITLE
Separate coverage for each processDefinition in HTML-reports

### DIFF
--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/AggregatedCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/AggregatedCoverage.java
@@ -37,6 +37,14 @@ public interface AggregatedCoverage {
     Set<String> getCoveredSequenceFlowIds(String processDefinitionKey);
 
     /**
+     * Retrieves covered sequence flow IDs for the given process definition key.
+     *
+     * @param processDefinitionKey
+     * @return
+     */
+    Set<CoveredSequenceFlow> getCoveredSequenceFlows(String processDefinitionKey);
+
+    /**
      * Retrieves the process definitions of the coverage.
      * 
      * @return
@@ -50,4 +58,11 @@ public interface AggregatedCoverage {
      */
     double getCoveragePercentage();
 
+    /**
+     * Retrieves the coverage percentage for the given process definition key.
+     *
+     * @param processDefinitionKey
+     * @return
+     */
+    double getCoveragePercentage(String processDefinitionKey);
 }

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/ClassCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/ClassCoverage.java
@@ -90,6 +90,31 @@ public class ClassCoverage implements AggregatedCoverage {
     }
 
     /**
+     * Retrieves the class coverage percentage for the given process definition key.
+     * All covered test methods' elements are aggregated and checked against the
+     * process definition elements.
+     *
+     * @param processDefinitionKey
+     * @return The coverage percentage.
+     */
+    @Override
+    public double getCoveragePercentage(String processDefinitionKey) {
+        // All deployments must be the same, so we take the first one
+        final MethodCoverage anyDeployment = getAnyMethodCoverage();
+
+        final Set<FlowNode> definitionsFlowNodes = anyDeployment.getProcessDefinitionsFlowNodes(processDefinitionKey);
+        final Set<SequenceFlow> definitionsSeqenceFlows = anyDeployment.getProcessDefinitionsSequenceFlows(processDefinitionKey);
+
+        final Set<CoveredFlowNode> coveredFlowNodes = getCoveredFlowNodes(processDefinitionKey);
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = getCoveredSequenceFlows(processDefinitionKey);
+
+        final double bpmnElementsCount = definitionsFlowNodes.size() + definitionsSeqenceFlows.size();
+        final double coveredElementsCount = coveredFlowNodes.size() + coveredSequenceFlows.size();
+
+        return coveredElementsCount / bpmnElementsCount;
+    }
+
+    /**
      * Retrieves the covered flow nodes.
      * Flow nodes with the same element ID but different process definition keys are retained. {@see CoveredElementComparator}
      * 
@@ -168,6 +193,22 @@ public class ClassCoverage implements AggregatedCoverage {
         }
 
         return coveredSequenceFlowIds;
+    }
+
+    /**
+     * Retrieves a set of covered sequence flows for the given process
+     * definition key.
+     * @param processDefinitionKey
+     */
+    public Set<CoveredSequenceFlow> getCoveredSequenceFlows(String processDefinitionKey) {
+
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = new TreeSet<CoveredSequenceFlow>(CoveredElementComparator.instance());
+        for (MethodCoverage methodCoverage : testNameToMethodCoverage.values()) {
+
+            coveredSequenceFlows.addAll(methodCoverage.getCoveredSequenceFlows(processDefinitionKey));
+        }
+
+        return coveredSequenceFlows;
     }
 
     /**

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
@@ -84,10 +84,10 @@ public class MethodCoverage implements AggregatedCoverage {
 
         // Aggregate element collections
 
-        final Set<CoveredElement> deploymentCoveredFlowNodes = new HashSet<CoveredElement>();
+        final Set<CoveredFlowNode> deploymentCoveredFlowNodes = new HashSet<>();
         final Set<FlowNode> deploymentDefinitionsFlowNodes = new HashSet<FlowNode>();
 
-        final Set<CoveredElement> deploymentCoveredSequenceFlows = new HashSet<CoveredElement>();
+        final Set<CoveredSequenceFlow> deploymentCoveredSequenceFlows = new HashSet<>();
         final Set<SequenceFlow> deploymentDefinitionsSequenceFlows = new HashSet<SequenceFlow>();
 
         // Collect defined and covered elements for all definitions in the method deployment
@@ -120,6 +120,29 @@ public class MethodCoverage implements AggregatedCoverage {
     }
 
     /**
+     * Retrieves the coverage percentage for the given process definition key
+     * with the method.
+     * @param processDefinitionKey
+     */
+    public double getCoveragePercentage(String processDefinitionKey) {
+
+        ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+
+        final Set<CoveredFlowNode> coveredFlowNodes = processCoverage.getCoveredFlowNodes();
+        final Set<FlowNode> definitionFlowNodes = processCoverage.getDefinitionFlowNodes();
+
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = processCoverage.getCoveredSequenceFlows();
+        final Set<SequenceFlow> definitionSequenceFlows = processCoverage.getDefinitionSequenceFlows();
+
+        // Calculate coverage
+        final double coveragePercentage = getCoveragePercentage(
+                coveredFlowNodes, definitionFlowNodes,
+                coveredSequenceFlows, definitionSequenceFlows);
+
+        return coveragePercentage;
+    }
+
+    /**
      * Calculates the process coverage percentage according to the passed defined and covered elements.
      * 
      * @param coveredFlowNodes Covered flow nodes possibly from multiple process definitions.
@@ -129,8 +152,8 @@ public class MethodCoverage implements AggregatedCoverage {
      * 
      * @return Coverage percentage of all process definitions combined.
      */
-    private double getCoveragePercentage(Set<CoveredElement> coveredFlowNodes, Set<FlowNode> definitionsFlowNodes,
-            Set<CoveredElement> coveredSequenceFlows, Set<SequenceFlow> definitionsSequenceFlows) {
+    private double getCoveragePercentage(Set<CoveredFlowNode> coveredFlowNodes, Set<FlowNode> definitionsFlowNodes,
+                                         Set<CoveredSequenceFlow> coveredSequenceFlows, Set<SequenceFlow> definitionsSequenceFlows) {
 
         final int numberOfDefinedElements = definitionsFlowNodes.size() + definitionsSequenceFlows.size();
         final int numberOfCoveredElemenets = coveredFlowNodes.size() + coveredSequenceFlows.size();
@@ -157,6 +180,19 @@ public class MethodCoverage implements AggregatedCoverage {
     }
 
     /**
+     * Retrieves the flow nodes for the process definition identified by the passed key in the method deployment.
+     * @param processDefinitionKey
+     * @return
+     */
+    public Set<FlowNode> getProcessDefinitionsFlowNodes(String processDefinitionKey) {
+
+        final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+        final Set<FlowNode> definitionFlowNodes = processCoverage.getDefinitionFlowNodes();
+
+        return definitionFlowNodes;
+    }
+
+    /**
      * Retrieves the sequence flows of all the process definitions in the method deployment.
      * @return
      */
@@ -169,6 +205,19 @@ public class MethodCoverage implements AggregatedCoverage {
             sequenceFlows.addAll(definitionSequenceFlows);
 
         }
+
+        return sequenceFlows;
+    }
+
+    /**
+     * Retrieves the sequence flows for the process definition identified by the passed key in the method deployment.
+     * @param processDefinitionKey
+     * @return
+     */
+    public Set<SequenceFlow> getProcessDefinitionsSequenceFlows(String processDefinitionKey) {
+
+        final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+        final Set<SequenceFlow> sequenceFlows = processCoverage.getDefinitionSequenceFlows();
 
         return sequenceFlows;
     }
@@ -232,6 +281,17 @@ public class MethodCoverage implements AggregatedCoverage {
 
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
         return processCoverage.getCoveredSequenceFlowIds();
+    }
+
+    /**
+     * Retrieves a set of elements of sequence flows of the process definition identified by the passed key.
+     * @return
+     */
+    @Override
+    public Set<CoveredSequenceFlow> getCoveredSequenceFlows(String processDefinitionKey) {
+
+        final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+        return processCoverage.getCoveredSequenceFlows();
     }
 
     /**

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
@@ -111,7 +111,7 @@ public class CoverageReportUtil {
                         coveredSequenceFlowIds,
                         reportName,
                         processDefinition.getKey(),
-                        coverage.getCoveragePercentage(),
+                        coverage.getCoveragePercentage(processDefinition.getKey()),
                         testClass,
                         testName,
                         classReport,

--- a/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/MultipleDeploymentsForClassTest.java
+++ b/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/MultipleDeploymentsForClassTest.java
@@ -1,0 +1,93 @@
+package org.camunda.bpm.extension.process_test_coverage.rules;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.extension.process_test_coverage.util.CoverageReportUtil;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Multiple deployments per test method test.
+ *
+ * @author ov7a
+ */
+@Deployment(resources = {"superProcess-single-branch.bpmn", "process.bpmn"})
+public class MultipleDeploymentsForClassTest {
+
+    private static final String PROCESS_DEFINITION_KEY = "super-process-test-coverage-single-branch";
+    private static final String SUB_PROCESS_DEFINITION_KEY = "process-test-coverage";
+    private static final double THRESHOLD = 0.05;
+    private static final Pattern coveragePattern = Pattern.compile("<div>Coverage:\\s*?([\\d.]*?)\\s*?%</div>");
+
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().build();
+
+    public static TestWatcher checkReportRule = new TestWatcher() {
+        @Override
+        protected void finished(Description description) {
+            if (!description.isTest()) {
+                checkReports(description);
+            }
+        }
+    };
+
+    private static String getReportPath(String processDefinitionKey, String className) {
+        return String.format("%s/%s/%s.html", CoverageReportUtil.TARGET_DIR_ROOT, className, processDefinitionKey);
+    }
+
+    private static double getCoverageInReport(String reportPath) {
+        try (Scanner scanner = new Scanner(new File(reportPath))){
+            while (scanner.hasNext()) {
+                String line = scanner.nextLine();
+                Matcher matcher = coveragePattern.matcher(line);
+                if (matcher.find()){
+                    return Double.parseDouble(matcher.group(1));
+                }
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        fail("No coverage information was found for " + reportPath);
+        return -1.0;
+    }
+
+    private static void assertCoverageInReport(String processDefinitionKey, String className, double expectedCoverage) {
+        String reportPath = getReportPath(processDefinitionKey, className);
+        double coverage = getCoverageInReport(reportPath);
+        assertEquals(expectedCoverage, coverage, THRESHOLD);
+    }
+
+    public static void checkReports(Description description) {
+        String className = description.getClassName();
+        assertCoverageInReport(PROCESS_DEFINITION_KEY, className, 100.0);
+        assertCoverageInReport(SUB_PROCESS_DEFINITION_KEY, className, 63.6);
+    }
+
+    @Rule
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(checkReportRule).around(rule);
+
+    @Test
+    public void runTestForSinglePath() {
+        Map<String, Object> variables = new HashMap<String, Object>();
+        variables.put("path", "A");
+        rule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY, variables);
+    }
+}

--- a/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/MultipleDeploymentsForClassTest.java
+++ b/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/MultipleDeploymentsForClassTest.java
@@ -85,6 +85,8 @@ public class MultipleDeploymentsForClassTest {
     public static RuleChain chain = RuleChain.outerRule(checkReportRule).around(rule);
 
     @Test
+    //duplicating Deployment annotation for backward compatibility with camunda-bpm-engine-7.3.0
+    @Deployment(resources = {"superProcess-single-branch.bpmn", "process.bpmn"})
     public void runTestForSinglePath() {
         Map<String, Object> variables = new HashMap<String, Object>();
         variables.put("path", "A");

--- a/test/src/test/resources/superProcess-single-branch.bpmn
+++ b/test/src/test/resources/superProcess-single-branch.bpmn
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:activiti="http://activiti.org/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.2">
+  <bpmn:process id="super-process-test-coverage-single-branch" name="super-process-test-coverage-single-branch" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0myldbf</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0myldbf" sourceRef="StartEvent_1" targetRef="CallActivity_Subprocess" />
+    <bpmn:callActivity id="CallActivity_Subprocess" name="Test Subprocess" calledElement="process-test-coverage">
+      <bpmn:extensionElements>
+        <activiti:in source="path" target="path" />
+        <activiti:in source="superPath" target="superPath" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0myldbf</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_SuperA</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="SequenceFlow_SuperA" sourceRef="CallActivity_Subprocess" targetRef="ManualTask_SuperA" />
+    <bpmn:endEvent id="EndEvent_1nexhxp">
+      <bpmn:incoming>SequenceFlow_0j7y0ob</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j7y0ob" sourceRef="ManualTask_SuperA" targetRef="EndEvent_1nexhxp" />
+    <bpmn:manualTask id="ManualTask_SuperA" name="Super A">
+      <bpmn:incoming>SequenceFlow_SuperA</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0j7y0ob</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="super-process-test-coverage">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0myldbf_di" bpmnElement="SequenceFlow_0myldbf">
+        <di:waypoint xsi:type="dc:Point" x="209" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="299" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="209" y="110" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_0poct8v_di" bpmnElement="CallActivity_Subprocess">
+        <dc:Bounds x="299" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_05pplai_di" bpmnElement="SequenceFlow_SuperA">
+        <di:waypoint xsi:type="dc:Point" x="399" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="594" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="444" y="69" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1nexhxp_di" bpmnElement="EndEvent_1nexhxp">
+        <dc:Bounds x="826" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="799" y="138" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j7y0ob_di" bpmnElement="SequenceFlow_0j7y0ob">
+        <di:waypoint xsi:type="dc:Point" x="694" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="826" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="715" y="110" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ManualTask_0d3xdj7_di" bpmnElement="ManualTask_SuperA">
+        <dc:Bounds x="594" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Added an interface to calculate coverage separately for each processDefinition. The coverage percent in HTML report now corresponds for single process definition coverage instead of deployment total coverage. Fixes #53