### PR TITLE
Shared CoverageTestRunState feature

### DIFF
--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/AggregatedCoverageTestRunState.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/AggregatedCoverageTestRunState.java
@@ -1,0 +1,90 @@
+package org.camunda.bpm.extension.process_test_coverage.junit.rules;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.extension.process_test_coverage.model.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author ov7a
+ */
+public class AggregatedCoverageTestRunState implements CoverageTestRunState {
+
+    private CoverageTestRunState currentCoverageTestRunState = null;
+
+    private List<ClassCoverage> classCoverages = new ArrayList<ClassCoverage>();
+
+    public void switchToNewState(CoverageTestRunState newState){
+        finishState();
+        currentCoverageTestRunState = newState;
+    }
+
+    private void finishState(){
+        if (currentCoverageTestRunState != null){
+            classCoverages.add(currentCoverageTestRunState.getClassCoverage());
+            currentCoverageTestRunState = null;
+        }
+    }
+
+    public AggregatedCoverage getAggregatedCoverage(){
+        finishState();
+        return new AggregatedClassCoverage(classCoverages);
+    }
+
+    @Override
+    public void addCoveredElement(CoveredElement coveredElement) {
+        currentCoverageTestRunState.addCoveredElement(coveredElement);
+    }
+
+    @Override
+    public void endCoveredElement(CoveredElement coveredElement) {
+        currentCoverageTestRunState.endCoveredElement(coveredElement);
+    }
+
+    @Override
+    public void initializeTestMethodCoverage(ProcessEngine processEngine, String deploymentId, List<ProcessDefinition> processDefinitions, String testName) {
+        currentCoverageTestRunState.initializeTestMethodCoverage(processEngine, deploymentId, processDefinitions, testName);
+    }
+
+    @Override
+    public MethodCoverage getTestMethodCoverage(String testName) {
+        return currentCoverageTestRunState.getTestMethodCoverage(testName);
+    }
+
+    @Override
+    public MethodCoverage getCurrentTestMethodCoverage() {
+        return currentCoverageTestRunState.getCurrentTestMethodCoverage();
+    }
+
+    @Override
+    public ClassCoverage getClassCoverage() {
+        return currentCoverageTestRunState.getClassCoverage();
+    }
+
+    @Override
+    public String getCurrentTestMethodName() {
+        return currentCoverageTestRunState.getCurrentTestMethodName();
+    }
+
+    @Override
+    public void setCurrentTestMethodName(String currentTestName) {
+        currentCoverageTestRunState.setCurrentTestMethodName(currentTestName);
+    }
+
+    @Override
+    public String getTestClassName() {
+        return currentCoverageTestRunState.getTestClassName();
+    }
+
+    @Override
+    public void setTestClassName(String className) {
+        currentCoverageTestRunState.setTestClassName(className);
+    }
+
+    @Override
+    public void setExcludedProcessDefinitionKeys(List<String> excludedProcessDefinitionKeys) {
+        currentCoverageTestRunState.setExcludedProcessDefinitionKeys(excludedProcessDefinitionKeys);
+    }
+}

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/AggregatedCoverageTestRunStateFactory.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/AggregatedCoverageTestRunStateFactory.java
@@ -1,0 +1,28 @@
+package org.camunda.bpm.extension.process_test_coverage.junit.rules;
+
+import java.util.List;
+
+/**
+ * @author ov7a
+ */
+public class AggregatedCoverageTestRunStateFactory implements CoverageTestRunStateFactory {
+
+    private AggregatedCoverageTestRunState coverageTestRunStateInstance;
+    private CoverageTestRunStateFactory coverageTestRunStateFactory;
+
+    public AggregatedCoverageTestRunStateFactory(AggregatedCoverageTestRunState coverageTestRunStateInstance) {
+        this(coverageTestRunStateInstance, new DefaultCoverageTestRunStateFactory());
+    }
+
+    public AggregatedCoverageTestRunStateFactory(AggregatedCoverageTestRunState coverageTestRunStateInstance, CoverageTestRunStateFactory coverageTestRunStateFactory) {
+        this.coverageTestRunStateInstance = coverageTestRunStateInstance;
+        this.coverageTestRunStateFactory = coverageTestRunStateFactory;
+    }
+
+    @Override
+    public CoverageTestRunState create(String className, List<String> excludedProcessDefinitionKeys) {
+        CoverageTestRunState newState = coverageTestRunStateFactory.create(className, excludedProcessDefinitionKeys);
+        coverageTestRunStateInstance.switchToNewState(newState);
+        return coverageTestRunStateInstance;
+    }
+}

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/CoverageTestRunState.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/CoverageTestRunState.java
@@ -1,79 +1,31 @@
 package org.camunda.bpm.extension.process_test_coverage.junit.rules;
 
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.extension.process_test_coverage.model.ClassCoverage;
 import org.camunda.bpm.extension.process_test_coverage.model.CoveredElement;
 import org.camunda.bpm.extension.process_test_coverage.model.MethodCoverage;
-import org.camunda.bpm.extension.process_test_coverage.model.ProcessCoverage;
+
+import java.util.List;
 
 /**
  * State tracking the current class and method coverage run.
- * 
- * @author grossax
- * @author z0rbas
- */
-public class CoverageTestRunState {
-
-    private Logger log = Logger.getLogger(CoverageTestRunState.class.getCanonicalName());
-
-    /**
-     * The actual class coverage object.
-     */
-    private ClassCoverage classCoverage = new ClassCoverage();
-
-    /**
-     * The test class name.
-     */
-    private String testClassName;
-
-    /**
-     * The name of the currently executing test method.
-     */
-    private String currentTestMethodName;
-
-    /**
-     * A list of process definition keys excluded from the test run.
-     */
-    private List<String> excludedProcessDefinitionKeys;
+  */
+public interface CoverageTestRunState {
 
     /**
      * Adds the covered element to the current test run coverage.
      * 
      * @param coveredElement
      */
-    public void addCoveredElement(/* @NotNull */ CoveredElement coveredElement) {
-
-        if (!isExcluded(coveredElement)) {
-            if (log.isLoggable(Level.FINE)) {
-                log.info("addCoveredElement(" + coveredElement + ")");
-            }
-
-            classCoverage.addCoveredElement(currentTestMethodName, coveredElement);
-        }
-
-    }
+    void addCoveredElement(/* @NotNull */ CoveredElement coveredElement);
 
     /**
      * Mark a covered element execution as ended.
      * 
      * @param coveredElement
      */
-    public void endCoveredElement(CoveredElement coveredElement) {
-
-        if (!isExcluded(coveredElement)) {
-            if (log.isLoggable(Level.FINE)) {
-                log.info("endCoveredElement(" + coveredElement + ")");
-            }
-
-            classCoverage.endCoveredElement(currentTestMethodName, coveredElement);
-        }
-
-    }
+    void endCoveredElement(CoveredElement coveredElement);
 
     /**
      * Adds a test method to the class coverage.
@@ -87,22 +39,8 @@ public class CoverageTestRunState {
      * @param testName
      *            The name of the test method.
      */
-    public void initializeTestMethodCoverage(ProcessEngine processEngine, String deploymentId,
-            List<ProcessDefinition> processDefinitions, String testName) {
-
-        final MethodCoverage testCoverage = new MethodCoverage(deploymentId);
-        for (ProcessDefinition processDefinition : processDefinitions) {
-
-            // Construct the pristine coverage object
-
-            // TODO decide on the builders fate
-            final ProcessCoverage processCoverage = new ProcessCoverage(processEngine, processDefinition);
-
-            testCoverage.addProcessCoverage(processCoverage);
-        }
-
-        classCoverage.addTestMethodCoverage(testName, testCoverage);
-    }
+    void initializeTestMethodCoverage(ProcessEngine processEngine, String deploymentId,
+            List<ProcessDefinition> processDefinitions, String testName);
 
     /**
      * Retrieves the coverage for a test method.
@@ -110,63 +48,40 @@ public class CoverageTestRunState {
      * @param testName
      * @return
      */
-    public MethodCoverage getTestMethodCoverage(String testName) {
-        return classCoverage.getTestMethodCoverage(testName);
-    }
+    MethodCoverage getTestMethodCoverage(String testName);
 
     /**
      * Retrieves the currently executing test method coverage.
      * 
      * @return
      */
-    public MethodCoverage getCurrentTestMethodCoverage() {
-        return classCoverage.getTestMethodCoverage(currentTestMethodName);
-    }
+    MethodCoverage getCurrentTestMethodCoverage();
 
     /**
      * Retrieves the class coverage.
      * 
      * @return
      */
-    public ClassCoverage getClassCoverage() {
-        return classCoverage;
-    }
+    ClassCoverage getClassCoverage();
 
     /**
      * Retrieves the name of the currently executing test method.
      * 
      * @return
      */
-    public String getCurrentTestMethodName() {
-        return currentTestMethodName;
-    }
+    String getCurrentTestMethodName();
 
     /**
      * Sets the name of the currently executing test mehod.
      * 
      * @param currentTestName
      */
-    public void setCurrentTestMethodName(String currentTestName) {
-        this.currentTestMethodName = currentTestName;
-    }
+    void setCurrentTestMethodName(String currentTestName);
 
-    public String getTestClassName() {
-        return testClassName;
-    }
+    String getTestClassName();
 
-    public void setTestClassName(String className) {
-        this.testClassName = className;
-    }
+    void setTestClassName(String className);
 
-    public void setExcludedProcessDefinitionKeys(List<String> excludedProcessDefinitionKeys) {
-        this.excludedProcessDefinitionKeys = excludedProcessDefinitionKeys;
-    }
-
-    private boolean isExcluded(CoveredElement coveredElement) {
-        if (excludedProcessDefinitionKeys != null) {
-            return excludedProcessDefinitionKeys.contains(coveredElement.getProcessDefinitionKey());
-        }
-        return false;
-    }
+    void setExcludedProcessDefinitionKeys(List<String> excludedProcessDefinitionKeys);
 
 }

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/CoverageTestRunStateFactory.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/CoverageTestRunStateFactory.java
@@ -1,0 +1,10 @@
+package org.camunda.bpm.extension.process_test_coverage.junit.rules;
+
+import java.util.List;
+
+/**
+ * @author ov7a
+ */
+public interface CoverageTestRunStateFactory {
+    CoverageTestRunState create(String className, List<String> excludedProcessDefinitionKeys);
+}

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/DefaultCoverageTestRunState.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/DefaultCoverageTestRunState.java
@@ -1,0 +1,183 @@
+package org.camunda.bpm.extension.process_test_coverage.junit.rules;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.extension.process_test_coverage.model.ClassCoverage;
+import org.camunda.bpm.extension.process_test_coverage.model.CoveredElement;
+import org.camunda.bpm.extension.process_test_coverage.model.MethodCoverage;
+import org.camunda.bpm.extension.process_test_coverage.model.ProcessCoverage;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * State tracking the current class and method coverage run.
+ * 
+ * @author grossax
+ * @author z0rbas
+ */
+public class DefaultCoverageTestRunState implements CoverageTestRunState {
+
+    private Logger log = Logger.getLogger(DefaultCoverageTestRunState.class.getCanonicalName());
+
+    /**
+     * The actual class coverage object.
+     */
+    private ClassCoverage classCoverage = new ClassCoverage();
+
+    /**
+     * The test class name.
+     */
+    private String testClassName;
+
+    /**
+     * The name of the currently executing test method.
+     */
+    private String currentTestMethodName;
+
+    /**
+     * A list of process definition keys excluded from the test run.
+     */
+    private List<String> excludedProcessDefinitionKeys;
+
+    /**
+     * Adds the covered element to the current test run coverage.
+     * 
+     * @param coveredElement
+     */
+    @Override
+    public void addCoveredElement(/* @NotNull */ CoveredElement coveredElement) {
+
+        if (!isExcluded(coveredElement)) {
+            if (log.isLoggable(Level.FINE)) {
+                log.info("addCoveredElement(" + coveredElement + ")");
+            }
+
+            classCoverage.addCoveredElement(currentTestMethodName, coveredElement);
+        }
+
+    }
+
+    /**
+     * Mark a covered element execution as ended.
+     * 
+     * @param coveredElement
+     */
+    @Override
+    public void endCoveredElement(CoveredElement coveredElement) {
+
+        if (!isExcluded(coveredElement)) {
+            if (log.isLoggable(Level.FINE)) {
+                log.info("endCoveredElement(" + coveredElement + ")");
+            }
+
+            classCoverage.endCoveredElement(currentTestMethodName, coveredElement);
+        }
+
+    }
+
+    /**
+     * Adds a test method to the class coverage.
+     * 
+     * @param processEngine
+     * @param deploymentId
+     *            The deployment ID of the test method run. (Hint: Every test
+     *            method run has its own deployment.)
+     * @param processDefinitions
+     *            The process definitions of the test method deployment.
+     * @param testName
+     *            The name of the test method.
+     */
+    @Override
+    public void initializeTestMethodCoverage(ProcessEngine processEngine, String deploymentId,
+            List<ProcessDefinition> processDefinitions, String testName) {
+
+        final MethodCoverage testCoverage = new MethodCoverage(deploymentId);
+        for (ProcessDefinition processDefinition : processDefinitions) {
+
+            // Construct the pristine coverage object
+
+            // TODO decide on the builders fate
+            final ProcessCoverage processCoverage = new ProcessCoverage(processEngine, processDefinition);
+
+            testCoverage.addProcessCoverage(processCoverage);
+        }
+
+        classCoverage.addTestMethodCoverage(testName, testCoverage);
+    }
+
+    /**
+     * Retrieves the coverage for a test method.
+     * 
+     * @param testName
+     * @return
+     */
+    @Override
+    public MethodCoverage getTestMethodCoverage(String testName) {
+        return classCoverage.getTestMethodCoverage(testName);
+    }
+
+    /**
+     * Retrieves the currently executing test method coverage.
+     * 
+     * @return
+     */
+    @Override
+    public MethodCoverage getCurrentTestMethodCoverage() {
+        return classCoverage.getTestMethodCoverage(currentTestMethodName);
+    }
+
+    /**
+     * Retrieves the class coverage.
+     * 
+     * @return
+     */
+    @Override
+    public ClassCoverage getClassCoverage() {
+        return classCoverage;
+    }
+
+    /**
+     * Retrieves the name of the currently executing test method.
+     * 
+     * @return
+     */
+    @Override
+    public String getCurrentTestMethodName() {
+        return currentTestMethodName;
+    }
+
+    /**
+     * Sets the name of the currently executing test mehod.
+     * 
+     * @param currentTestName
+     */
+    @Override
+    public void setCurrentTestMethodName(String currentTestName) {
+        this.currentTestMethodName = currentTestName;
+    }
+
+    @Override
+    public String getTestClassName() {
+        return testClassName;
+    }
+
+    @Override
+    public void setTestClassName(String className) {
+        this.testClassName = className;
+    }
+
+    @Override
+    public void setExcludedProcessDefinitionKeys(List<String> excludedProcessDefinitionKeys) {
+        this.excludedProcessDefinitionKeys = excludedProcessDefinitionKeys;
+    }
+
+    private boolean isExcluded(CoveredElement coveredElement) {
+        if (excludedProcessDefinitionKeys != null) {
+            return excludedProcessDefinitionKeys.contains(coveredElement.getProcessDefinitionKey());
+        }
+        return false;
+    }
+
+}

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/DefaultCoverageTestRunStateFactory.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/DefaultCoverageTestRunStateFactory.java
@@ -1,0 +1,16 @@
+package org.camunda.bpm.extension.process_test_coverage.junit.rules;
+
+import java.util.List;
+
+/**
+ * @author ov7a
+ */
+public class DefaultCoverageTestRunStateFactory implements CoverageTestRunStateFactory {
+    @Override
+    public CoverageTestRunState create(String className, List<String> excludedProcessDefinitionKeys) {
+        CoverageTestRunState coverageTestRunState = new DefaultCoverageTestRunState();
+        coverageTestRunState.setTestClassName(className);
+        coverageTestRunState.setExcludedProcessDefinitionKeys(excludedProcessDefinitionKeys);
+        return coverageTestRunState;
+    }
+}

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/TestCoverageProcessEngineRule.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/TestCoverageProcessEngineRule.java
@@ -1,16 +1,5 @@
 package org.camunda.bpm.extension.process_test_coverage.junit.rules;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseListener;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -23,7 +12,6 @@ import org.camunda.bpm.extension.process_test_coverage.listeners.FlowNodeHistory
 import org.camunda.bpm.extension.process_test_coverage.listeners.PathCoverageParseListener;
 import org.camunda.bpm.extension.process_test_coverage.model.AggregatedCoverage;
 import org.camunda.bpm.extension.process_test_coverage.model.ClassCoverage;
-import org.camunda.bpm.extension.process_test_coverage.model.CoveredElement;
 import org.camunda.bpm.extension.process_test_coverage.model.MethodCoverage;
 import org.camunda.bpm.extension.process_test_coverage.util.CoverageReportUtil;
 import org.hamcrest.Matcher;
@@ -31,6 +19,11 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.Description;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Rule handling the process test coverage for individual test methods and the
@@ -66,6 +59,11 @@ public class TestCoverageProcessEngineRule extends ProcessEngineRule {
      * Log class and test method coverages?
      */
     private boolean detailedCoverageLogging = false;
+
+    /**
+     *  coverageTestRunStateFactory. Can be changed for aggregated/suite coverage check
+     */
+    private CoverageTestRunStateFactory coverageTestRunStateFactory = new DefaultCoverageTestRunStateFactory();
 
     /**
      * Matchers to be asserted on the class coverage percentage.
@@ -233,9 +231,7 @@ public class TestCoverageProcessEngineRule extends ProcessEngineRule {
         // @Rule run
         if (firstRun) {
 
-            coverageTestRunState = new CoverageTestRunState();
-            coverageTestRunState.setTestClassName(description.getClassName());
-            coverageTestRunState.setExcludedProcessDefinitionKeys(excludedProcessDefinitionKeys);
+            coverageTestRunState = coverageTestRunStateFactory.create(description.getClassName(), excludedProcessDefinitionKeys);
 
             initializeListenerRunState();
 
@@ -392,6 +388,10 @@ public class TestCoverageProcessEngineRule extends ProcessEngineRule {
 
     public void setDetailedCoverageLogging(boolean detailedCoverageLogging) {
         this.detailedCoverageLogging = detailedCoverageLogging;
+    }
+
+    public void setCoverageTestRunStateFactory(CoverageTestRunStateFactory coverageTestRunStateFactory) {
+        this.coverageTestRunStateFactory = coverageTestRunStateFactory;
     }
 
     @Override

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/TestCoverageProcessEngineRuleBuilder.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/junit/rules/TestCoverageProcessEngineRuleBuilder.java
@@ -94,6 +94,16 @@ public class TestCoverageProcessEngineRuleBuilder {
     }
 
     /**
+     * Configures CoverageTestRunStateFactory used to create CoverageTestRunState. Useful for sharing state between several test-classes
+     * @param coverageTestRunStateFactory
+     * @return
+     */
+    public TestCoverageProcessEngineRuleBuilder setCoverageTestRunStateFactory(CoverageTestRunStateFactory coverageTestRunStateFactory) {
+        rule.setCoverageTestRunStateFactory(coverageTestRunStateFactory);
+        return this;
+    }
+
+    /**
      * Asserts if the class coverage is greater than the passed percentage.
      * 
      * @param percentage

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/AggregatedClassCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/AggregatedClassCoverage.java
@@ -1,0 +1,154 @@
+package org.camunda.bpm.extension.process_test_coverage.model;
+
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.extension.process_test_coverage.util.CoveredElementComparator;
+import org.camunda.bpm.model.bpmn.instance.FlowNode;
+import org.camunda.bpm.model.bpmn.instance.SequenceFlow;
+
+import java.util.*;
+
+/**
+ * Test class coverage model. The class coverage is an aggregation of all test method coverages.
+ *
+ * @author ov7a
+ */
+public class AggregatedClassCoverage implements AggregatedCoverage {
+
+    private List<ClassCoverage> classCoverages;
+    private Map<String, List<ClassCoverage>> classCoveragesByProcessDefinitionKey = new HashMap<String, List<ClassCoverage>>();
+
+    public AggregatedClassCoverage(List<ClassCoverage> classCoverages) {
+        this.classCoverages = classCoverages;
+        organizeByProcessDefinitionKey();
+    }
+
+    private void organizeByProcessDefinitionKey() {
+        for (ClassCoverage classCoverage : classCoverages) {
+            for (ProcessDefinition processDefinition : classCoverage.getProcessDefinitions()) {
+                String key = processDefinition.getKey();
+                if (!classCoveragesByProcessDefinitionKey.containsKey(key)) {
+                    classCoveragesByProcessDefinitionKey.put(key, new ArrayList<ClassCoverage>());
+                }
+                classCoveragesByProcessDefinitionKey.get(key).add(classCoverage);
+            }
+        }
+    }
+
+    @Override
+    public Set<String> getCoveredFlowNodeIds(String processDefinitionKey) {
+
+        final Set<String> coveredFlowNodeIds = new HashSet<String>();
+        for (ClassCoverage classCoverage : classCoveragesByProcessDefinitionKey.get(processDefinitionKey)) {
+
+            coveredFlowNodeIds.addAll(classCoverage.getCoveredFlowNodeIds(processDefinitionKey));
+        }
+
+        return coveredFlowNodeIds;
+    }
+
+    @Override
+    public Set<CoveredFlowNode> getCoveredFlowNodes(String processDefinitionKey) {
+
+        final Set<CoveredFlowNode> coveredFlowNodes = new TreeSet<CoveredFlowNode>(CoveredElementComparator.instance());
+
+        for (ClassCoverage classCoverage : classCoveragesByProcessDefinitionKey.get(processDefinitionKey)) {
+
+            coveredFlowNodes.addAll(classCoverage.getCoveredFlowNodes(processDefinitionKey));
+        }
+
+        return coveredFlowNodes;
+    }
+
+    @Override
+    public Set<String> getCoveredSequenceFlowIds(String processDefinitionKey) {
+
+        final Set<String> coveredSequenceFlowIds = new HashSet<String>();
+        for (ClassCoverage classCoverage : classCoveragesByProcessDefinitionKey.get(processDefinitionKey)) {
+
+            coveredSequenceFlowIds.addAll(classCoverage.getCoveredSequenceFlowIds(processDefinitionKey));
+        }
+
+        return coveredSequenceFlowIds;
+    }
+
+    @Override
+    public Set<CoveredSequenceFlow> getCoveredSequenceFlows(String processDefinitionKey) {
+
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = new TreeSet<CoveredSequenceFlow>(CoveredElementComparator.instance());
+        for (ClassCoverage classCoverage : classCoveragesByProcessDefinitionKey.get(processDefinitionKey)) {
+
+            coveredSequenceFlows.addAll(classCoverage.getCoveredSequenceFlows(processDefinitionKey));
+        }
+
+        return coveredSequenceFlows;
+    }
+
+    @Override
+    public Set<ProcessDefinition> getProcessDefinitions() {
+
+        final Set<ProcessDefinition> processDefinitions = new TreeSet<ProcessDefinition>(
+                new Comparator<ProcessDefinition>() {
+
+                    // Avoid removing process definitions with the same key, but coming from different BPMNs.
+                    @Override
+                    public int compare(ProcessDefinition o1, ProcessDefinition o2) {
+                        return o1.getResourceName().compareTo(o2.getResourceName());
+                    }
+                });
+
+        for (ClassCoverage classCoverage : classCoverages) {
+            processDefinitions.addAll(classCoverage.getProcessDefinitions());
+        }
+
+        return processDefinitions;
+    }
+
+    @Override
+    public double getCoveragePercentage() {
+
+        Set<ProcessDefinition> processDefinitions = getProcessDefinitions();
+
+        final Set<FlowNode> definitionsFlowNodes = new HashSet<FlowNode>();
+        final Set<SequenceFlow> definitionsSequenceFlows = new HashSet<SequenceFlow>();
+
+        final Set<CoveredFlowNode> coveredFlowNodes = new TreeSet<CoveredFlowNode>(CoveredElementComparator.instance());
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = new TreeSet<CoveredSequenceFlow>(CoveredElementComparator.instance());
+
+        for (ProcessDefinition processDefinition : processDefinitions) {
+            String processDefinitionKey = processDefinition.getKey();
+
+            final MethodCoverage deploymentWithProcessDefinition = getMethodCoverage(processDefinitionKey);
+
+            definitionsFlowNodes.addAll(deploymentWithProcessDefinition.getProcessDefinitionsFlowNodes(processDefinitionKey));
+            definitionsSequenceFlows.addAll(deploymentWithProcessDefinition.getProcessDefinitionsSequenceFlows(processDefinitionKey));
+
+            coveredFlowNodes.addAll(getCoveredFlowNodes(processDefinitionKey));
+            coveredSequenceFlows.addAll(getCoveredSequenceFlows(processDefinitionKey));
+        }
+
+        final double bpmnElementsCount = definitionsFlowNodes.size() + definitionsSequenceFlows.size();
+        final double coveredElementsCount = coveredFlowNodes.size() + coveredSequenceFlows.size();
+
+        return coveredElementsCount / bpmnElementsCount;
+    }
+
+    @Override
+    public double getCoveragePercentage(String processDefinitionKey) {
+        final MethodCoverage deploymentWithProcessDefinition = getMethodCoverage(processDefinitionKey);
+
+        final Set<FlowNode> definitionsFlowNodes = deploymentWithProcessDefinition.getProcessDefinitionsFlowNodes(processDefinitionKey);
+        final Set<SequenceFlow> definitionsSequenceFlows = deploymentWithProcessDefinition.getProcessDefinitionsSequenceFlows(processDefinitionKey);
+
+        final Set<CoveredFlowNode> coveredFlowNodes = getCoveredFlowNodes(processDefinitionKey);
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = getCoveredSequenceFlows(processDefinitionKey);
+
+        final double bpmnElementsCount = definitionsFlowNodes.size() + definitionsSequenceFlows.size();
+        final double coveredElementsCount = coveredFlowNodes.size() + coveredSequenceFlows.size();
+
+        return coveredElementsCount / bpmnElementsCount;
+    }
+
+    private MethodCoverage getMethodCoverage(String processDefinitionKey) {
+        return classCoveragesByProcessDefinitionKey.get(processDefinitionKey).get(0).getAnyMethodCoverage();
+    }
+}

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/AggregatedCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/AggregatedCoverage.java
@@ -37,6 +37,14 @@ public interface AggregatedCoverage {
     Set<String> getCoveredSequenceFlowIds(String processDefinitionKey);
 
     /**
+     * Retrieves covered sequence flow IDs for the given process definition key.
+     *
+     * @param processDefinitionKey
+     * @return
+     */
+    Set<CoveredSequenceFlow> getCoveredSequenceFlows(String processDefinitionKey);
+
+    /**
      * Retrieves the process definitions of the coverage.
      * 
      * @return
@@ -50,4 +58,11 @@ public interface AggregatedCoverage {
      */
     double getCoveragePercentage();
 
+    /**
+     * Retrieves the coverage percentage for the given process definition key.
+     *
+     * @param processDefinitionKey
+     * @return
+     */
+    double getCoveragePercentage(String processDefinitionKey);
 }

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/ClassCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/ClassCoverage.java
@@ -90,6 +90,31 @@ public class ClassCoverage implements AggregatedCoverage {
     }
 
     /**
+     * Retrieves the class coverage percentage for the given process definition key.
+     * All covered test methods' elements are aggregated and checked against the
+     * process definition elements.
+     *
+     * @param processDefinitionKey
+     * @return The coverage percentage.
+     */
+    @Override
+    public double getCoveragePercentage(String processDefinitionKey) {
+        // All deployments must be the same, so we take the first one
+        final MethodCoverage anyDeployment = getAnyMethodCoverage();
+
+        final Set<FlowNode> definitionsFlowNodes = anyDeployment.getProcessDefinitionsFlowNodes(processDefinitionKey);
+        final Set<SequenceFlow> definitionsSeqenceFlows = anyDeployment.getProcessDefinitionsSequenceFlows(processDefinitionKey);
+
+        final Set<CoveredFlowNode> coveredFlowNodes = getCoveredFlowNodes(processDefinitionKey);
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = getCoveredSequenceFlows(processDefinitionKey);
+
+        final double bpmnElementsCount = definitionsFlowNodes.size() + definitionsSeqenceFlows.size();
+        final double coveredElementsCount = coveredFlowNodes.size() + coveredSequenceFlows.size();
+
+        return coveredElementsCount / bpmnElementsCount;
+    }
+
+    /**
      * Retrieves the covered flow nodes.
      * Flow nodes with the same element ID but different process definition keys are retained. {@see CoveredElementComparator}
      * 
@@ -168,6 +193,22 @@ public class ClassCoverage implements AggregatedCoverage {
         }
 
         return coveredSequenceFlowIds;
+    }
+
+    /**
+     * Retrieves a set of covered sequence flows for the given process
+     * definition key.
+     * @param processDefinitionKey
+     */
+    public Set<CoveredSequenceFlow> getCoveredSequenceFlows(String processDefinitionKey) {
+
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = new TreeSet<CoveredSequenceFlow>(CoveredElementComparator.instance());
+        for (MethodCoverage methodCoverage : testNameToMethodCoverage.values()) {
+
+            coveredSequenceFlows.addAll(methodCoverage.getCoveredSequenceFlows(processDefinitionKey));
+        }
+
+        return coveredSequenceFlows;
     }
 
     /**

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/ClassCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/ClassCoverage.java
@@ -1,16 +1,12 @@
 package org.camunda.bpm.extension.process_test_coverage.model;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.extension.process_test_coverage.util.CoveredElementComparator;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.camunda.bpm.model.bpmn.instance.SequenceFlow;
 import org.junit.Assert;
+
+import java.util.*;
 
 /**
  * Test class coverage model. The class coverage is an aggregation of all test method coverages.
@@ -225,7 +221,7 @@ public class ClassCoverage implements AggregatedCoverage {
      * 
      * @return
      */
-    private MethodCoverage getAnyMethodCoverage() {
+    protected MethodCoverage getAnyMethodCoverage() {
 
         // All deployments must be the same, so we take the first one
         final MethodCoverage anyDeployment = testNameToMethodCoverage.values().iterator().next();

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
@@ -84,10 +84,10 @@ public class MethodCoverage implements AggregatedCoverage {
 
         // Aggregate element collections
 
-        final Set<CoveredElement> deploymentCoveredFlowNodes = new HashSet<CoveredElement>();
+        final Set<CoveredFlowNode> deploymentCoveredFlowNodes = new HashSet<>();
         final Set<FlowNode> deploymentDefinitionsFlowNodes = new HashSet<FlowNode>();
 
-        final Set<CoveredElement> deploymentCoveredSequenceFlows = new HashSet<CoveredElement>();
+        final Set<CoveredSequenceFlow> deploymentCoveredSequenceFlows = new HashSet<>();
         final Set<SequenceFlow> deploymentDefinitionsSequenceFlows = new HashSet<SequenceFlow>();
 
         // Collect defined and covered elements for all definitions in the method deployment
@@ -120,6 +120,29 @@ public class MethodCoverage implements AggregatedCoverage {
     }
 
     /**
+     * Retrieves the coverage percentage for the given process definition key
+     * with the method.
+     * @param processDefinitionKey
+     */
+    public double getCoveragePercentage(String processDefinitionKey) {
+
+        ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+
+        final Set<CoveredFlowNode> coveredFlowNodes = processCoverage.getCoveredFlowNodes();
+        final Set<FlowNode> definitionFlowNodes = processCoverage.getDefinitionFlowNodes();
+
+        final Set<CoveredSequenceFlow> coveredSequenceFlows = processCoverage.getCoveredSequenceFlows();
+        final Set<SequenceFlow> definitionSequenceFlows = processCoverage.getDefinitionSequenceFlows();
+
+        // Calculate coverage
+        final double coveragePercentage = getCoveragePercentage(
+                coveredFlowNodes, definitionFlowNodes,
+                coveredSequenceFlows, definitionSequenceFlows);
+
+        return coveragePercentage;
+    }
+
+    /**
      * Calculates the process coverage percentage according to the passed defined and covered elements.
      * 
      * @param coveredFlowNodes Covered flow nodes possibly from multiple process definitions.
@@ -129,8 +152,8 @@ public class MethodCoverage implements AggregatedCoverage {
      * 
      * @return Coverage percentage of all process definitions combined.
      */
-    private double getCoveragePercentage(Set<CoveredElement> coveredFlowNodes, Set<FlowNode> definitionsFlowNodes,
-            Set<CoveredElement> coveredSequenceFlows, Set<SequenceFlow> definitionsSequenceFlows) {
+    private double getCoveragePercentage(Set<CoveredFlowNode> coveredFlowNodes, Set<FlowNode> definitionsFlowNodes,
+                                         Set<CoveredSequenceFlow> coveredSequenceFlows, Set<SequenceFlow> definitionsSequenceFlows) {
 
         final int numberOfDefinedElements = definitionsFlowNodes.size() + definitionsSequenceFlows.size();
         final int numberOfCoveredElemenets = coveredFlowNodes.size() + coveredSequenceFlows.size();
@@ -157,6 +180,19 @@ public class MethodCoverage implements AggregatedCoverage {
     }
 
     /**
+     * Retrieves the flow nodes for the process definition identified by the passed key in the method deployment.
+     * @param processDefinitionKey
+     * @return
+     */
+    public Set<FlowNode> getProcessDefinitionsFlowNodes(String processDefinitionKey) {
+
+        final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+        final Set<FlowNode> definitionFlowNodes = processCoverage.getDefinitionFlowNodes();
+
+        return definitionFlowNodes;
+    }
+
+    /**
      * Retrieves the sequence flows of all the process definitions in the method deployment.
      * @return
      */
@@ -169,6 +205,19 @@ public class MethodCoverage implements AggregatedCoverage {
             sequenceFlows.addAll(definitionSequenceFlows);
 
         }
+
+        return sequenceFlows;
+    }
+
+    /**
+     * Retrieves the sequence flows for the process definition identified by the passed key in the method deployment.
+     * @param processDefinitionKey
+     * @return
+     */
+    public Set<SequenceFlow> getProcessDefinitionsSequenceFlows(String processDefinitionKey) {
+
+        final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+        final Set<SequenceFlow> sequenceFlows = processCoverage.getDefinitionSequenceFlows();
 
         return sequenceFlows;
     }
@@ -232,6 +281,17 @@ public class MethodCoverage implements AggregatedCoverage {
 
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
         return processCoverage.getCoveredSequenceFlowIds();
+    }
+
+    /**
+     * Retrieves a set of elements of sequence flows of the process definition identified by the passed key.
+     * @return
+     */
+    @Override
+    public Set<CoveredSequenceFlow> getCoveredSequenceFlows(String processDefinitionKey) {
+
+        final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
+        return processCoverage.getCoveredSequenceFlows();
     }
 
     /**

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/BpmnJsReport.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/BpmnJsReport.java
@@ -139,14 +139,14 @@ public class BpmnJsReport {
         if (testClass == null) {
             html = html.replaceAll(PLACEHOLDER_TESTCLASS, "");
         } else {
-            html = html.replaceAll(PLACEHOLDER_TESTCLASS, "<div>Test Class: " + testClass + "</div>");
+            html = html.replaceAll(PLACEHOLDER_TESTCLASS, "<div>Test Class: " + testClass.replace('$', '.') + "</div>");
         }
 
         // Class reports don't have the method field in the info-box
         if (testMethod == null) {
             html = html.replaceAll(PLACEHOLDER_TESTMETHOD, "");
         } else {
-            html = html.replaceAll(PLACEHOLDER_TESTMETHOD, "<div>TestMethod: " + testMethod + "</div>");
+            html = html.replaceAll(PLACEHOLDER_TESTMETHOD, "<div>TestMethod: " + testMethod.replace('$', '.') + "</div>");
         }
 
       return html;

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/BpmnJsReport.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/BpmnJsReport.java
@@ -1,15 +1,15 @@
 package org.camunda.bpm.extension.process_test_coverage.util;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.camunda.bpm.extension.process_test_coverage.model.CoveredFlowNode;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
 import java.util.Collection;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
-import org.camunda.bpm.extension.process_test_coverage.model.CoveredFlowNode;
 
 /**
  * Util generating graphical process test coverage reports.
@@ -65,21 +65,16 @@ public class BpmnJsReport {
    * @param bpmnXml The BPMN XML of the report process definition. 
    * @param flowNodes Flow nodes to be highlighted.
    * @param sequenceFlowIds Sequence flows to be highlighted.
-   * @param reportName The file name of the report.
+   * @param reportPath The file path of the report.
    * @param processDefinitionKey The key of the report process definition.
    * @param coverage The coverage percentage.
    * @param testClass The name of the test class.
    * @param testMethod The name of the test method if applicable.
-   * @param classReport When true a class report will be generated, otherwise a method report.
-   * The difference is mainly in the info-box method name field not appearing.
-   * @param targetDir The directory where the report will be stored.
-     * 
    * @throws IOException Thrown if an error occurs on report template read or report write.
      */
     public static void generateReportWithHighlightedFlowNodesAndSequenceFlows(String bpmnXml,
-            Collection<CoveredFlowNode> flowNodes, Collection<String> sequenceFlowIds, String reportName,
-            String processDefinitionKey, double coverage, String testClass, String testMethod, boolean classReport,
-            String targetDir) throws IOException {
+            Collection<CoveredFlowNode> flowNodes, Collection<String> sequenceFlowIds, String reportPath,
+            String processDefinitionKey, double coverage, String testClass, String testMethod) throws IOException {
 
         final String flowNodeMarkers = generateJavaScriptFlowNodeAnnotations(flowNodes);
         final String sequenceFlowMarkers = generateJavaScriptSequenceFlowAnnotations(sequenceFlowIds);
@@ -90,9 +85,8 @@ public class BpmnJsReport {
                 processDefinitionKey,
                 coverage,
                 testClass,
-                testMethod,
-                classReport);
-        writeToFile(targetDir, reportName, html);
+                testMethod);
+        writeToFile(reportPath, html);
 
     }
 
@@ -105,18 +99,16 @@ public class BpmnJsReport {
    * @param coverage The coverage percentage.
    * @param testClass The name of the test class.
    * @param testMethod The name of the test method if applicable.
-   * @param classReport When true a class report will be generated, otherwise a method report.
-   * The difference is mainly in the info-box method name field not appearing.
-     * @return
+   * @return
    * @throws IOException Thrown if an error occurs on report template read.
      */
   protected static String generateHtml(String javaScript, String bpmnXml,
           String processDefinitionKey, double coverage, String testClass, 
-          String testMethod, boolean classReport) throws IOException {
+          String testMethod) throws IOException {
 
         String html = IOUtils.toString(CoverageReportUtil.class.getClassLoader().getResourceAsStream(REPORT_TEMPLATE));
 		return injectIntoHtmlTemplate(javaScript, bpmnXml, html, processDefinitionKey, coverage,
-		        testClass, testMethod, classReport);
+		        testClass, testMethod);
     }
 
     /**
@@ -129,30 +121,35 @@ public class BpmnJsReport {
    * @param coverage The coverage percentage.
    * @param testClass The name of the test class.
    * @param testMethod The name of the test method if applicable.
-   * @param classReport When true a class report will be generated, otherwise a method report.
-     * 
+     *
      * @return Complete html report.
      */
   protected static String injectIntoHtmlTemplate(
           String javaScript, String bpmnXml,
           String html, String processDefinitionKey,
           double coverage, String testClass,
-          String testMethod, boolean classReport) {
+          String testMethod) {
 
         html = html.replace(PLACEHOLDER_BPMN_XML, StringEscapeUtils.escapeEcmaScript(bpmnXml));
         html = html.replaceAll(PLACEHOLDER_ANNOTATIONS, javaScript + PLACEHOLDER_ANNOTATIONS);
         html = html.replaceAll(PLACEHOLDER_PROCESS_KEY, processDefinitionKey);
         html = html.replaceAll(PLACEHOLDER_COVERAGE, getCoveragePercent(coverage));
-        html = html.replaceAll(PLACEHOLDER_TESTCLASS, testClass);
+
+        // Suite reports don't have the class field in the info-box
+        if (testClass == null) {
+            html = html.replaceAll(PLACEHOLDER_TESTCLASS, "");
+        } else {
+            html = html.replaceAll(PLACEHOLDER_TESTCLASS, "<div>Test Class: " + testClass + "</div>");
+        }
 
         // Class reports don't have the method field in the info-box
-        if (classReport) {
+        if (testMethod == null) {
             html = html.replaceAll(PLACEHOLDER_TESTMETHOD, "");
         } else {
             html = html.replaceAll(PLACEHOLDER_TESTMETHOD, "<div>TestMethod: " + testMethod + "</div>");
         }
 
-        return html;
+      return html;
     }
 
     /**
@@ -216,13 +213,12 @@ public class BpmnJsReport {
     /**
      * Write the html report.
      * 
-     * @param targetDir
-     * @param fileName
+     * @param filePath
      * @param html
      * @throws IOException
      */
-    protected static void writeToFile(String targetDir, String fileName, String html) throws IOException {
-        FileUtils.writeStringToFile(new File(targetDir + "/" + fileName), html);
+    protected static void writeToFile(String filePath, String html) throws IOException {
+        FileUtils.writeStringToFile(new File(filePath), html);
     }
 
 }

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
@@ -111,7 +111,7 @@ public class CoverageReportUtil {
                         coveredSequenceFlowIds,
                         reportName,
                         processDefinition.getKey(),
-                        coverage.getCoveragePercentage(),
+                        coverage.getCoveragePercentage(processDefinition.getKey()),
                         testClass,
                         testName,
                         classReport,

--- a/core/src/main/resources/bpmn.js-report-template.html
+++ b/core/src/main/resources/bpmn.js-report-template.html
@@ -69,7 +69,7 @@
   <div id="info-box">
 	<div>Process Definition Name: //PROCESSKEY</div>
 	<div>Coverage: //COVERAGE</div>
-	<div>Test Class: //TESTCLASS</div>
+	//TESTCLASS
 	//TESTMETHOD
   </div>
   

--- a/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/AggregatedCoverageTestRunStateTest.java
+++ b/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/AggregatedCoverageTestRunStateTest.java
@@ -1,0 +1,115 @@
+package org.camunda.bpm.extension.process_test_coverage.rules;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.*;
+import org.camunda.bpm.extension.process_test_coverage.util.CoverageReportUtil;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Shared coverageTestRunStateTest
+ *
+ * @author ov7a
+ */
+@RunWith(Enclosed.class)
+public class AggregatedCoverageTestRunStateTest {
+    private static final String SUB_PROCESS_DEFINITION_KEY = "process-test-coverage";
+    private static final String AGGREGATED_REPORT_PATH = CoverageReportUtil.TARGET_DIR_ROOT + "/aggregated_report/coverage";
+    private static final double THRESHOLD = 0.05;
+    private static final Pattern coveragePattern = Pattern.compile("<div>Coverage:\\s*?([\\d.]*?)\\s*?%</div>");
+
+    private static final AggregatedCoverageTestRunState sharedCoverageState = new AggregatedCoverageTestRunState();
+    private static final CoverageTestRunStateFactory coverageTestRunStateFactory = new AggregatedCoverageTestRunStateFactory(sharedCoverageState);
+
+    public static class FirstNested {
+        public static final String PROCESS_DEFINITION_KEY = "super-process-test-coverage-single-branch";
+
+        @Rule
+        @ClassRule
+        public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder
+                .create()
+                .setCoverageTestRunStateFactory(coverageTestRunStateFactory)
+                .build();
+
+        @Test
+        @Deployment(resources = {"superProcess-single-branch.bpmn", "process.bpmn"})
+        public void runTestForSinglePath() {
+            Map<String, Object> variables = new HashMap<String, Object>();
+            variables.put("path", "A");
+            rule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY, variables);
+        }
+    }
+
+    public static class SecondNested {
+        public static final String PROCESS_DEFINITION_KEY = "super-process-test-coverage";
+
+        @Rule
+        @ClassRule
+        public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder
+                .create()
+                .setCoverageTestRunStateFactory(coverageTestRunStateFactory)
+                .build();
+
+        @Test
+        @Deployment(resources = { "superProcess.bpmn", "process.bpmn" })
+        public void testPathAAndSuperPathA() {
+            Map<String, Object> variables = new HashMap<String, Object>();
+            variables.put("path", "B");
+            variables.put("superPath", "A");
+            rule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY, variables);
+        }
+    }
+
+    @AfterClass
+    public static void createAndValidateCombinedReport(){
+        CoverageReportUtil.createReport(sharedCoverageState.getAggregatedCoverage(), AGGREGATED_REPORT_PATH);
+        checkReports();
+    }
+
+    private static String getReportPath(String processDefinitionKey) {
+        return String.format("%s/%s.html", AGGREGATED_REPORT_PATH, processDefinitionKey);
+    }
+
+    private static double getCoverageInReport(String reportPath) {
+        try (Scanner scanner = new Scanner(new File(reportPath))){
+            while (scanner.hasNext()) {
+                String line = scanner.nextLine();
+                Matcher matcher = coveragePattern.matcher(line);
+                if (matcher.find()){
+                    return Double.parseDouble(matcher.group(1));
+                }
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        fail("No coverage information was found for " + reportPath);
+        return -1.0;
+    }
+
+    private static void assertCoverageInReport(String processDefinitionKey, double expectedCoverage) {
+        String reportPath = getReportPath(processDefinitionKey);
+        double coverage = getCoverageInReport(reportPath);
+        assertEquals(expectedCoverage, coverage, THRESHOLD);
+    }
+
+    public static void checkReports() {
+        assertCoverageInReport(FirstNested.PROCESS_DEFINITION_KEY, 100.0);
+        assertCoverageInReport(SecondNested.PROCESS_DEFINITION_KEY, 69.2);
+        assertCoverageInReport(SUB_PROCESS_DEFINITION_KEY, 100.0);
+    }
+}

--- a/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/MultipleDeploymentsForClassTest.java
+++ b/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/MultipleDeploymentsForClassTest.java
@@ -1,0 +1,93 @@
+package org.camunda.bpm.extension.process_test_coverage.rules;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.extension.process_test_coverage.util.CoverageReportUtil;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Multiple deployments per test method test.
+ *
+ * @author ov7a
+ */
+@Deployment(resources = {"superProcess-single-branch.bpmn", "process.bpmn"})
+public class MultipleDeploymentsForClassTest {
+
+    private static final String PROCESS_DEFINITION_KEY = "super-process-test-coverage-single-branch";
+    private static final String SUB_PROCESS_DEFINITION_KEY = "process-test-coverage";
+    private static final double THRESHOLD = 0.05;
+    private static final Pattern coveragePattern = Pattern.compile("<div>Coverage:\\s*?([\\d.]*?)\\s*?%</div>");
+
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().build();
+
+    public static TestWatcher checkReportRule = new TestWatcher() {
+        @Override
+        protected void finished(Description description) {
+            if (!description.isTest()) {
+                checkReports(description);
+            }
+        }
+    };
+
+    private static String getReportPath(String processDefinitionKey, String className) {
+        return String.format("%s/%s/%s.html", CoverageReportUtil.TARGET_DIR_ROOT, className, processDefinitionKey);
+    }
+
+    private static double getCoverageInReport(String reportPath) {
+        try (Scanner scanner = new Scanner(new File(reportPath))){
+            while (scanner.hasNext()) {
+                String line = scanner.nextLine();
+                Matcher matcher = coveragePattern.matcher(line);
+                if (matcher.find()){
+                    return Double.parseDouble(matcher.group(1));
+                }
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        fail("No coverage information was found for " + reportPath);
+        return -1.0;
+    }
+
+    private static void assertCoverageInReport(String processDefinitionKey, String className, double expectedCoverage) {
+        String reportPath = getReportPath(processDefinitionKey, className);
+        double coverage = getCoverageInReport(reportPath);
+        assertEquals(expectedCoverage, coverage, THRESHOLD);
+    }
+
+    public static void checkReports(Description description) {
+        String className = description.getClassName();
+        assertCoverageInReport(PROCESS_DEFINITION_KEY, className, 100.0);
+        assertCoverageInReport(SUB_PROCESS_DEFINITION_KEY, className, 63.6);
+    }
+
+    @Rule
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(checkReportRule).around(rule);
+
+    @Test
+    public void runTestForSinglePath() {
+        Map<String, Object> variables = new HashMap<String, Object>();
+        variables.put("path", "A");
+        rule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY, variables);
+    }
+}

--- a/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/MultipleDeploymentsForClassTest.java
+++ b/test/src/test/java/org/camunda/bpm/extension/process_test_coverage/rules/MultipleDeploymentsForClassTest.java
@@ -85,6 +85,8 @@ public class MultipleDeploymentsForClassTest {
     public static RuleChain chain = RuleChain.outerRule(checkReportRule).around(rule);
 
     @Test
+    //duplicating Deployment annotation for backward compatibility with camunda-bpm-engine-7.3.0
+    @Deployment(resources = {"superProcess-single-branch.bpmn", "process.bpmn"})
     public void runTestForSinglePath() {
         Map<String, Object> variables = new HashMap<String, Object>();
         variables.put("path", "A");

--- a/test/src/test/resources/superProcess-single-branch.bpmn
+++ b/test/src/test/resources/superProcess-single-branch.bpmn
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:activiti="http://activiti.org/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.2">
+  <bpmn:process id="super-process-test-coverage-single-branch" name="super-process-test-coverage-single-branch" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0myldbf</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0myldbf" sourceRef="StartEvent_1" targetRef="CallActivity_Subprocess" />
+    <bpmn:callActivity id="CallActivity_Subprocess" name="Test Subprocess" calledElement="process-test-coverage">
+      <bpmn:extensionElements>
+        <activiti:in source="path" target="path" />
+        <activiti:in source="superPath" target="superPath" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0myldbf</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_SuperA</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="SequenceFlow_SuperA" sourceRef="CallActivity_Subprocess" targetRef="ManualTask_SuperA" />
+    <bpmn:endEvent id="EndEvent_1nexhxp">
+      <bpmn:incoming>SequenceFlow_0j7y0ob</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j7y0ob" sourceRef="ManualTask_SuperA" targetRef="EndEvent_1nexhxp" />
+    <bpmn:manualTask id="ManualTask_SuperA" name="Super A">
+      <bpmn:incoming>SequenceFlow_SuperA</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0j7y0ob</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="super-process-test-coverage">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0myldbf_di" bpmnElement="SequenceFlow_0myldbf">
+        <di:waypoint xsi:type="dc:Point" x="209" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="299" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="209" y="110" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_0poct8v_di" bpmnElement="CallActivity_Subprocess">
+        <dc:Bounds x="299" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_05pplai_di" bpmnElement="SequenceFlow_SuperA">
+        <di:waypoint xsi:type="dc:Point" x="399" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="594" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="444" y="69" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1nexhxp_di" bpmnElement="EndEvent_1nexhxp">
+        <dc:Bounds x="826" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="799" y="138" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j7y0ob_di" bpmnElement="SequenceFlow_0j7y0ob">
+        <di:waypoint xsi:type="dc:Point" x="694" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="826" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="715" y="110" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ManualTask_0d3xdj7_di" bpmnElement="ManualTask_SuperA">
+        <dc:Bounds x="594" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
 `CoverageTestRunState` can now be shared between several class instances (e.g. for Suites).

This can be useful in case when a combined coverage report for multiple process definitions is required. Shared state is stored outside of Rule.

`CoverageTestRunState` is now an interface and created by a factory. `DefaultCoverageTestRunState` is the same as the old `CoverageTestRunState`. `AggregatedCoverageTestRunState` stores current `CoverageTestRunState`, changes it for each new test class and persists `ClassCoverage`s in `AggregatedClassCoverage`.

Report creation is slightly refactored to accept `AggregatedClassCoverage` and potentially store aggregated report in non-default directory.