### PR TITLE
Update SpringProcessWithCoverageEngineConfiguration.java

### DIFF
--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/spring/SpringProcessWithCoverageEngineConfiguration.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/spring/SpringProcessWithCoverageEngineConfiguration.java
@@ -12,7 +12,7 @@ import org.camunda.bpm.extension.process_test_coverage.junit.rules.ProcessCovera
  */
 public class SpringProcessWithCoverageEngineConfiguration extends SpringProcessEngineConfiguration {
 
-	public void init() {
+	protected void init() {
 		ProcessCoverageConfigurator.initializeProcessCoverageExtensions(this);
 		super.init();
 	}


### PR DESCRIPTION
In the `ProcessEngineConfigurationImpl`, the `init`  method is `protected` as nobody should call it (application context must be initialized when init is called)